### PR TITLE
Add extension to retrieve routing slip from bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Then kick off the process by sending a message and including the list of destina
     
 Each endpoint needs to include a handler for the message. Optionally, each endpoint can inspect/modify routing slip attachments:
 
-    Bus.GetRoutingSlipFromCurrentMessage().Attachments["FraudResult"] = "Declined";
+    Bus.RoutingSlip().Attachments["FraudResult"] = "Declined";
     
 That's all there is to it!

--- a/src/NServiceBus.MessageRouting/RoutingSlips/RoutableMessageBusExtensions.cs
+++ b/src/NServiceBus.MessageRouting/RoutingSlips/RoutableMessageBusExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace NServiceBus.MessageRouting.RoutingSlips
 {
@@ -30,6 +31,14 @@ namespace NServiceBus.MessageRouting.RoutingSlips
             var router = new Router(bus);
 
             router.SendToFirstStep(message, routingSlip);
+        }
+
+        public static RoutingSlip RoutingSlip(this IBus bus)
+        {
+            string routingSlip;
+            if (bus.CurrentMessageContext.Headers.TryGetValue(Router.RoutingSlipHeaderKey, out routingSlip))
+                return JsonConvert.DeserializeObject<RoutingSlip>(routingSlip);
+            return null;
         }
     }
 }


### PR DESCRIPTION
The GetRoutingSlipFromCurrentMessage() extension was missing.